### PR TITLE
Add telephone line and company mode faces

### DIFF
--- a/cosmos-dark-theme.el
+++ b/cosmos-dark-theme.el
@@ -130,8 +130,8 @@
    `(success ((t (:foreground ,earth-300))))
    `(error ((t (:foreground ,mars-300))))
    `(warning ((t (:foreground ,sun-700))))
-   `(link ((t (:foreground ,uranus-700 :underline t))))
-   `(link-visited ((t (:foreground ,venus-500 :underline t :slant italic))))
+   `(link ((t (:foreground ,uranus-500 :underline t))))
+   `(link-visited ((t (:foreground ,venus-700 :underline t :slant italic))))
    `(region ((t (:background ,uranus-800))))
    `(shadow ((t (:foreground ,space-300))))
    `(highlight ((t (:background ,earth-300 :foreground ,uranus-800))))
@@ -140,7 +140,7 @@
    `(font-lock-builtin-face               ((t (:foreground  ,venus-200 :slant italic))))
    `(font-lock-comment-delimiter-face     ((t (:inherit     (font-lock-comment-face)))))
    `(font-lock-comment-face               ((t (:foreground  ,space-700   :slant italic))))
-   `(font-lock-constant-face              ((t (:foreground  ,sun-400))))
+   `(font-lock-constant-face              ((t (:foreground  ,earth-400))))
    `(font-lock-doc-face                   ((t (:foreground  ,earth-600 :inherit font-lock-comment-face))))
    `(font-lock-function-name-face         ((t (:foreground  ,uranus-300))))
    `(font-lock-keyword-face               ((t (:foreground  ,venus-500))))
@@ -148,7 +148,7 @@
    `(font-lock-regexp-grouping-backslash  ((t (:foreground  ,sun-600   :inherit bold))))
    `(font-lock-regexp-grouping-construct  ((t (:foreground  ,sun-600   :inherit bold))))
    `(font-lock-string-face                ((t (:foreground  ,sun-600))))
-   `(font-lock-type-face                  ((t (:foreground  ,earth-300 :slant italic))))
+   `(font-lock-type-face                  ((t (:foreground  ,sun-300 :slant italic))))
    `(font-lock-variable-name-face         ((t (:foreground  ,uranus-600  :slant italic))))
    `(font-lock-warning-face               ((t (:foreground  ,mars-600))))
 
@@ -294,6 +294,14 @@
    `(mode-line-emphasis ((t (:foreground ,venus-400))))
    `(mode-line-highlight ((((class color) (min-colors 88)) (:box (:line-width 2 :color ,space-900 :style released-button))) (t (:inherit (highlight)))))
    `(mode-line-inactive ((t (:background ,moon-700 :foreground ,space-600 :box nil))))
+
+   ;; Telephone-line
+   `(telephone-line-evil-normal    ((t  (:background  ,mars-900    :inherit  telephone-line-evil))))
+   `(telephone-line-evil-insert    ((t  (:background  ,earth-800   :inherit  telephone-line-evil))))
+   `(telephone-line-evil-visual    ((t  (:background  ,sun-700     :inherit  telephone-line-evil))))
+   `(telephone-line-evil-operator  ((t  (:background  ,uranus-700  :inherit  telephone-line-evil))))
+   `(telephone-line-evil-emacs     ((t  (:background  ,venus-900   :inherit  telephone-line-evil))))
+   `(telephone-line-evil-motion    ((t  (:background  ,uranus-900  :inherit  telephone-line-evil))))
 
    ;; Isearch
    `(isearch ((t (:background ,sun-900 :foreground ,venus-400 ))))

--- a/cosmos-dark-theme.el
+++ b/cosmos-dark-theme.el
@@ -262,8 +262,14 @@
    `(web-mode-current-element-highlight-face  ((t  (:foreground  ,venus-800 :background ,earth-100))))
 
    ;; Company-mode
-   `(company-echo-common    ((t  (:foreground  ,mars-900))))
-   `(company-box-selection  ((t  (:background  ,sun-300))))
+   `(company-preview            ((t  (:background  ,venus-700               :foreground  ,moon-900))))
+   `(company-echo-common        ((t  (:background  ,venus-700               :foreground  ,moon-200))))
+   `(company-preview-common     ((t  (:inherit     company-echo-common))))
+   `(company-preview-search     ((t  (:foreground  ,space-900))))
+   `(company-box-selection      ((t  (:background  ,sun-300))))
+   `(company-tooltip            ((t  (:background  ,uranus-500              :foreground  ,moon-900))))
+   `(company-tooltip-selection  ((t  (:background  ,earth-500               :foreground  ,moon-900))))
+   `(company-tooltip-common     ((t  (:underline   t))))
 
    ;; Slack client faces
    `(slack-preview-face    ((t  (:background ,sun-100 :inherit org-code))))

--- a/cosmos-light-theme.el
+++ b/cosmos-light-theme.el
@@ -261,8 +261,14 @@
    `(web-mode-current-element-highlight-face  ((t  (:foreground  ,venus-800 :background ,earth-100))))
 
    ;; Company-mode
-   `(company-echo-common    ((t  (:foreground  ,mars-900))))
-   `(company-box-selection  ((t  (:background  ,sun-300))))
+   `(company-preview            ((t  (:background  ,uranus-500              :foreground  ,moon-900))))
+   `(company-echo-common        ((t  (:background  ,uranus-500              :foreground  ,moon-200))))
+   `(company-preview-common     ((t  (:inherit     company-echo-common))))
+   `(company-preview-search     ((t  (:foreground  ,space-900))))
+   `(company-box-selection      ((t  (:background  ,sun-300))))
+   `(company-tooltip            ((t  (:background  ,sun-200                 :foreground  ,moon-900))))
+   `(company-tooltip-selection  ((t  (:background  ,venus-400               :foreground  ,moon-900))))
+   `(company-tooltip-common     ((t  (:underline   t))))
 
    ;; Slack client faces
    `(slack-preview-face    ((t  (:background ,sun-100 :inherit org-code))))

--- a/cosmos-light-theme.el
+++ b/cosmos-light-theme.el
@@ -289,6 +289,14 @@
    `(mode-line-highlight ((((class color) (min-colors 88)) (:box (:line-width 2 :color "grey40" :style released-button))) (t (:inherit (highlight)))))
    `(mode-line-inactive ((t (:background ,space-300 :foreground ,space-600 :box nil))))
 
+   ;; Telephone-line
+   `(telephone-line-evil-normal    ((t  (:background  ,venus-500   :inherit  telephone-line-evil))))
+   `(telephone-line-evil-insert    ((t  (:background  ,earth-600   :inherit  telephone-line-evil))))
+   `(telephone-line-evil-visual    ((t  (:background  ,sun-600     :inherit  telephone-line-evil))))
+   `(telephone-line-evil-operator  ((t  (:background  ,uranus-500  :inherit  telephone-line-evil))))
+   `(telephone-line-evil-emacs     ((t  (:background  ,mars-700    :inherit  telephone-line-evil))))
+   `(telephone-line-evil-motion    ((t  (:background  ,uranus-700  :inherit  telephone-line-evil))))
+
    ;; Isearch
    `(isearch ((t (:background ,venus-600 :foreground ,uranus-300 ))))
    `(isearch-fail ((t (:background ,mars-400 :foreground ,space-300 :weight bold))))


### PR DESCRIPTION
This PR adds custom faces for `telephone-line-mode` and `company-mode`.

This idea came up while working on v2, but it wasn't detrimental to publish it.